### PR TITLE
Allow user to determine decoding tagtype

### DIFF
--- a/src/asn1.py
+++ b/src/asn1.py
@@ -398,7 +398,7 @@ class Decoder(object):
             self.m_tag = self._read_tag()
         return self.m_tag
 
-    def read(self):  # type: () -> (Tag, any)
+    def read(self, tagnr=None):  # type: (Number) -> (Tag, any)
         """This method decodes one ASN.1 tag from the input and returns it as a
         ``(tag, value)`` tuple. ``tag`` is a 3-tuple ``(nr, typ, cls)``,
         while ``value`` is a Python object representing the ASN.1 value.
@@ -418,7 +418,9 @@ class Decoder(object):
             return None
         tag = self.peek()
         length = self._read_length()
-        value = self._read_value(tag.nr, length)
+        if tagnr is None:
+            tagnr = tag.nr
+        value = self._read_value(tagnr, length)
         self.m_tag = None
         return tag, value
 


### PR DESCRIPTION
If for example the user wishes to decode an `Integer` as a `BitString` this change enables such behavior.
The change is not breaking as the `tagnr` defaults to the tagnr stored in the data that is being decoded.

### Example usage:

```python
import asn1

def decode_pubkey(pubkey):
    decoder = asn1.Decoder()
    decoder.start(bytes(pubkey))
    decoder.enter()
    _, pubmod = decoder.read(asn1.Numbers.BitString)
    _, pubexp = decoder.read(asn1.Numbers.BitString)
    return pubmod, pubexp
```

Please let me know what you think!