### PR TITLE
Fix parsing of Object IDs in example

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -6,3 +6,4 @@ The following people have contributed to Python-ASN1. Collectively they own the 
 
 * Geert Jansen <geert@boskant.nl>
 * Sebastien Andrivet <sebastien@andrivet.com>
+* Finian Blackett <finian.blackett@gmail.com>

--- a/examples/dump.py
+++ b/examples/dump.py
@@ -118,12 +118,12 @@ def object_identifier_to_string(identifier):
 
 
 def value_to_string(tag_number, value):
-    if isinstance(value, bytes):
+    if tag_number == asn1.Numbers.ObjectIdentifier:
+        return object_identifier_to_string(value)
+    elif isinstance(value, bytes):
         return '0x' + str(binascii.hexlify(value).upper())
     elif isinstance(value, str):
         return value
-    elif tag_number == asn1.Numbers.ObjectIdentifier:
-        return object_identifier_to_string(value)
     else:
         return repr(value)
 


### PR DESCRIPTION
Currently, the example doesn't ever use its table of the object names to turn them into their actual names. 
This fixes that.
Thanks. 