### PR TITLE
Install enum34 only for python versions < '3.4'

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 future==0.18.2
-enum-compat==0.0.3
+enum34==1.1.10; python_version < '3.4'
 


### PR DESCRIPTION
Following fix for #66 

The [enum-compat README](https://github.com/jstasiak/enum-compat) says:
> Don't really use this package – you may as well just depend on `enum34; python_version < "3.4"` in your code and you're good.

This PR does as suggested, but I'll close if you'd prefer to use `enum-compat`