### PR TITLE
Fix - Bad python version check on setup.py causes installation to fail

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -6,4 +6,5 @@ The following people have contributed to Python-ASN1. Collectively they own the 
 
 * Geert Jansen <geert@boskant.nl>
 * Sebastien Andrivet <sebastien@andrivet.com>
+* Marc Benet <marcbenet@gmail.com>
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,7 +1,14 @@
 Changelog
 =========
 
+2.4.1 (2020-07-15)
+------------------
+
+* Fix - Bad python version check on setup.py causes installation to fail on python versions higher than 3.4
+
+
 2.4.0 (2020-06-23)
+------------------
 
 * Fix #21 - Invalid decoding in non-Universal classes
 * Fix #57 - Invalid encoding of non-Universal classes

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ def read(*names, **kwargs):
 
 
 install_requires = []
-if version_info[0] < 3.4:
+if version_info[0] == 3 and version_info[1] < 4:
     install_requires.append('enum34')
 if version_info[0] < 3:
     install_requires.append('future')


### PR DESCRIPTION
I noticed that installing this package on python38 makes it fail due 'enum34' dependency. That happened the python version is not properly validated on `setup.py`.