### PR TITLE
Fixes to BitString decoding and encoding of IA5String and UTCTime (fixes #248)

### DIFF
--- a/src/asn1.py
+++ b/src/asn1.py
@@ -267,7 +267,9 @@ class Encoder(object):
             return value
         if nr in (Numbers.Integer, Numbers.Enumerated):
             return self._encode_integer(value)
-        if nr in (Numbers.OctetString, Numbers.PrintableString):
+        if nr in (Numbers.OctetString, Numbers.PrintableString,
+                  Numbers.UTF8String, Numbers.IA5String,
+                  Numbers.UnicodeString, Numbers.UTCTime):
             return self._encode_octet_string(value)
         if nr == Numbers.BitString:
             return self._encode_bit_string(value)
@@ -542,7 +544,7 @@ class Decoder(object):
             value = self._decode_null(bytes_data)
         elif nr == Numbers.ObjectIdentifier:
             value = self._decode_object_identifier(bytes_data)
-        elif nr in (Numbers.PrintableString, Numbers.IA5String, Numbers.UTCTime):
+        elif nr in (Numbers.PrintableString, Numbers.IA5String, Numbers.UTF8String, Numbers.UTCTime):
             value = self._decode_printable_string(bytes_data)
         elif nr == Numbers.BitString:
             value = self._decode_bitstring(bytes_data)

--- a/tests/test_asn1.py
+++ b/tests/test_asn1.py
@@ -974,6 +974,21 @@ class TestDecoder(object):
 class TestEncoderDecoder(object):
     """Test suite for ASN1 Encoder and Decoder."""
 
+    @staticmethod
+    def assert_encode_decode(v, t):
+        encoder = asn1.Encoder()
+        encoder.start()
+        encoder.write(v, t)
+        encoded_bytes = encoder.output()
+        decoder = asn1.Decoder()
+        decoder.start(encoded_bytes)
+        tag, value = decoder.read()
+        assert value == v
+
+    def test_boolean(self):
+        for v in (True, False):
+            TestEncoderDecoder.assert_encode_decode(v, asn1.Numbers.Boolean)
+
     def test_big_numbers(self):
         for v in \
         (
@@ -1007,3 +1022,70 @@ class TestEncoderDecoder(object):
             decoder.start(encoded_bytes)
             tag, value = decoder.read()
             assert value == v
+
+    def test_bitstring(self):
+        for v in \
+        (
+            b'\x12\x34\x56',
+            b'\x01',
+            b''
+        ):
+            TestEncoderDecoder.assert_encode_decode(v, asn1.Numbers.BitString)
+
+    def test_octet_string(self):
+        for v in \
+        (
+            b'foo',
+            b'',
+            b'A' * 257
+        ):
+            TestEncoderDecoder.assert_encode_decode(v, asn1.Numbers.OctetString)
+
+    def test_null(self):
+        TestEncoderDecoder.assert_encode_decode(None, asn1.Numbers.Null)
+
+    def test_object_identifier(self):
+        TestEncoderDecoder.assert_encode_decode(
+            '1.2.840.113554.1.2.1.1',
+            asn1.Numbers.ObjectIdentifier
+        )
+
+    def test_enumerated(self):
+        for v in (1, 2, 42):
+            TestEncoderDecoder.assert_encode_decode(v, asn1.Numbers.Enumerated)
+
+    def test_utf8_string(self):
+        for v in \
+        (
+            'foo',
+            u'fooé'
+        ):
+            TestEncoderDecoder.assert_encode_decode(v, asn1.Numbers.UTF8String)
+
+    def test_printable_string(self):
+        for v in \
+        (
+            'foo',
+            u'fooé'
+        ):
+            TestEncoderDecoder.assert_encode_decode(v, asn1.Numbers.PrintableString)
+
+    def test_ia5_string(self):
+        TestEncoderDecoder.assert_encode_decode('foo', asn1.Numbers.IA5String)
+
+    def test_utc_time(self):
+        for v in \
+        (
+            '920521000000Z',
+            '920622123421Z',
+            '920722132100Z'
+        ):
+            TestEncoderDecoder.assert_encode_decode(v, asn1.Numbers.UTCTime)
+
+    def test_unicode_string(self):
+        for v in \
+        (
+            b'foo',
+            u'fooé'.encode('utf-8')
+        ):
+            TestEncoderDecoder.assert_encode_decode(v, asn1.Numbers.UnicodeString)


### PR DESCRIPTION
Hi!

This PR fixes two issues I encountered:

1. When decoding BitStrings, the initial octet is not removed from the value. The initial octet stores the number of unused bits and is not part of the actual value. For BitStrings where this value is not equal to 0, the value furthermore needs to be modified before using. The first commit adds the necessary BitString decoding logic.
2. As reported in #248, there are currently issues with encoding values of type `str` as `IA5String` and `UTCTime`. On the other hand, the library decoded both `IA5String` and `UTCTime` as strings, meaning that `encode(decode(x))` would not work for these types.

I also added unit tests for both of these points. Happy to incorporate any feedback you might have!