### PR TITLE
Add support for GeneralizedTime (#235)

### DIFF
--- a/examples/dump.py
+++ b/examples/dump.py
@@ -48,6 +48,7 @@ tag_id_to_string_map = {
     asn1.Numbers.PrintableString: "PRINTABLESTRING",
     asn1.Numbers.IA5String: "IA5STRING",
     asn1.Numbers.UTCTime: "UTCTIME",
+    asn1.Numbers.GeneralizedTime: "GENERALIZED TIME",
     asn1.Numbers.Enumerated: "ENUMERATED",
     asn1.Numbers.Sequence: "SEQUENCE",
     asn1.Numbers.Set: "SET"

--- a/src/asn1.py
+++ b/src/asn1.py
@@ -42,6 +42,7 @@ class Numbers(IntEnum):
     PrintableString = 0x13
     IA5String = 0x16
     UTCTime = 0x17
+    GeneralizedTime = 0x18
     UnicodeString = 0x1e
 
 
@@ -269,7 +270,8 @@ class Encoder(object):
             return self._encode_integer(value)
         if nr in (Numbers.OctetString, Numbers.PrintableString,
                   Numbers.UTF8String, Numbers.IA5String,
-                  Numbers.UnicodeString, Numbers.UTCTime):
+                  Numbers.UnicodeString, Numbers.UTCTime,
+                  Numbers.GeneralizedTime):
             return self._encode_octet_string(value)
         if nr == Numbers.BitString:
             return self._encode_bit_string(value)
@@ -544,7 +546,9 @@ class Decoder(object):
             value = self._decode_null(bytes_data)
         elif nr == Numbers.ObjectIdentifier:
             value = self._decode_object_identifier(bytes_data)
-        elif nr in (Numbers.PrintableString, Numbers.IA5String, Numbers.UTF8String, Numbers.UTCTime):
+        elif nr in (Numbers.PrintableString, Numbers.IA5String, 
+                    Numbers.UTF8String, Numbers.UTCTime,
+                    Numbers.GeneralizedTime):
             value = self._decode_printable_string(bytes_data)
         elif nr == Numbers.BitString:
             value = self._decode_bitstring(bytes_data)

--- a/tests/test_asn1.py
+++ b/tests/test_asn1.py
@@ -1082,6 +1082,18 @@ class TestEncoderDecoder(object):
         ):
             TestEncoderDecoder.assert_encode_decode(v, asn1.Numbers.UTCTime)
 
+    def test_generalized_time(self):
+        for v in \
+        (
+            '19920521000000Z',
+            '19920622123421.123Z',
+            '20920722132100-0500',
+            '20920722132100+0200',
+            '20920722132100.123-0500',
+            '20920722132100.123+0200',
+        ):
+            TestEncoderDecoder.assert_encode_decode(v, asn1.Numbers.GeneralizedTime)
+
     def test_unicode_string(self):
         for v in \
         (


### PR DESCRIPTION
First of all, thank you so much for this library!

Since I also had the need to support `GeneralizedTime` in one of my projects, I looked into it and found that it works very similar to `UTCTime`, meaning the date/time string will just be encoded as-is (basically ASCII/UTF-8).