### PR TITLE
Some fixes for test GitHub Action

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,6 +19,8 @@ jobs:
       uses: LizardByte/setup-python-action@master
       with:
         python-version: ${{ matrix.python-version }}
+      env:
+        PIP_TRUSTED_HOST: "pypi.python.org pypi.org files.pythonhosted.org"
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip wheel

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,12 +11,12 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: ['2.7', '3.5', '3.6', '3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['2.7', '3.5', '3.6', '3.7', '3.8', '3.9', '3.10', '3.11', '3.12']
 
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: LizardByte/setup-python-action@master
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies


### PR DESCRIPTION
Since I noticed on #281 that the Actions were not quite right...

- Switch python-setup Github Action to slightly different action that allows deprecated python 2.7
- Add python 3.12 (test) support
- workaround for https://github.com/actions/setup-python/issues/866

All tests run successfully on my [manual run](https://github.com/nealian/python-asn1/actions/runs/10426972412/job/28880881394)