### PR TITLE
this package neved needed "future"

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -43,16 +43,6 @@ Features
 - Can be integrated by just including a file into your project
 
 
-Dependencies
-==============
-
-Python-ASN1 relies on `Python-Future <https://python-future.org>`_ for Python 2 and 3 compatibility. To install Python-Future:
-
-.. code-block:: sh
-
-  pip install future
-
-
 How to install Python-asn1
 ==========================
 

--- a/setup.py
+++ b/setup.py
@@ -24,8 +24,6 @@ def read(*names, **kwargs):
 
 
 install_requires = ['enum-compat']
-if version_info[0] < 3:
-    install_requires.append('future')
 
 setup(
     name='asn1',

--- a/tox.ini
+++ b/tox.ini
@@ -29,7 +29,6 @@ usedevelop = false
 deps =
     pytest
     nose
-    future
     enum-compat
     coverage
 commands =


### PR DESCRIPTION
Hi,

`__future__` and `future` are not the same thing. `__future__` is included in the standard library.