### PR TITLE
Use Enum with Tag for pretty repr

### DIFF
--- a/src/asn1.py
+++ b/src/asn1.py
@@ -29,7 +29,16 @@ from numbers import Number
 __version__ = "2.7.1"
 
 
-class Numbers(IntEnum):
+class HexEnum(IntEnum):
+    def __repr__(self):
+        return '<{cls}.{name}: 0x{value:02x}>'.format(
+            cls=type(self).__name__,
+            name=self.name,
+            value=self.value
+        )
+
+
+class Numbers(HexEnum):
     Boolean = 0x01
     Integer = 0x02
     BitString = 0x03
@@ -47,12 +56,12 @@ class Numbers(IntEnum):
     UnicodeString = 0x1e
 
 
-class Types(IntEnum):
+class Types(HexEnum):
     Constructed = 0x20
     Primitive = 0x00
 
 
-class Classes(IntEnum):
+class Classes(HexEnum):
     Universal = 0x00
     Application = 0x40
     Context = 0x80
@@ -551,6 +560,19 @@ class Decoder(object):
                 nr = (nr << 7) | (byte & 0x7f)
                 if not byte & 0x80:
                     break
+        try:
+            typ = Types(typ)
+        except ValueError:
+            pass
+        try:
+            cls = Classes(cls)
+        except ValueError:
+            pass
+        if cls == Classes.Universal:
+            try:
+                nr = Numbers(nr)
+            except ValueError:
+                pass
         return Tag(nr=nr, typ=typ, cls=cls)
 
     def _read_length(self):  # type: () -> int

--- a/tests/test_asn1.py
+++ b/tests/test_asn1.py
@@ -392,6 +392,7 @@ class TestDecoder(object):
         dec.start(buf)
         tag = dec.peek()
         assert tag == (asn1.Numbers.Boolean, asn1.Types.Primitive, asn1.Classes.Universal)
+        assert str(tag) == "Tag(nr=<Numbers.Boolean: 0x01>, typ=<Types.Primitive: 0x00>, cls=<Classes.Universal: 0x00>)"
         tag, val = dec.read()
         assert isinstance(val, int)
         assert val
@@ -412,6 +413,7 @@ class TestDecoder(object):
         dec.start(buf)
         tag = dec.peek()
         assert tag == (asn1.Numbers.Integer, asn1.Types.Primitive, asn1.Classes.Universal)
+        assert str(tag) == "Tag(nr=<Numbers.Integer: 0x02>, typ=<Types.Primitive: 0x00>, cls=<Classes.Universal: 0x00>)"
         tag, val = dec.read()
         assert isinstance(val, int)
         assert val == 1
@@ -462,6 +464,7 @@ class TestDecoder(object):
         dec.start(buf)
         tag = dec.peek()
         assert tag == (asn1.Numbers.OctetString, asn1.Types.Primitive, asn1.Classes.Universal)
+        assert str(tag) == "Tag(nr=<Numbers.OctetString: 0x04>, typ=<Types.Primitive: 0x00>, cls=<Classes.Universal: 0x00>)"
         tag, val = dec.read()
         assert val == b'foo'
 
@@ -471,6 +474,7 @@ class TestDecoder(object):
         dec.start(buf)
         tag = dec.peek()
         assert tag == (asn1.Numbers.PrintableString, asn1.Types.Primitive, asn1.Classes.Universal)
+        assert str(tag) == "Tag(nr=<Numbers.PrintableString: 0x13>, typ=<Types.Primitive: 0x00>, cls=<Classes.Universal: 0x00>)"
         tag, val = dec.read()
         assert val == u'foo'
 
@@ -480,6 +484,7 @@ class TestDecoder(object):
         dec.start(buf)
         tag = dec.peek()
         assert tag == (asn1.Numbers.BitString, asn1.Types.Primitive, asn1.Classes.Universal)
+        assert str(tag) == "Tag(nr=<Numbers.BitString: 0x03>, typ=<Types.Primitive: 0x00>, cls=<Classes.Universal: 0x00>)"
         tag, val = dec.read()
         assert val == b'\x12\x34\x56'
 
@@ -489,6 +494,7 @@ class TestDecoder(object):
         dec.start(buf)
         tag = dec.peek()
         assert tag == (asn1.Numbers.BitString, asn1.Types.Primitive, asn1.Classes.Universal)
+        assert str(tag) == "Tag(nr=<Numbers.BitString: 0x03>, typ=<Types.Primitive: 0x00>, cls=<Classes.Universal: 0x00>)"
         tag, val = dec.read()
         assert val == b'\x01\x23\x45'
 
@@ -498,6 +504,7 @@ class TestDecoder(object):
         dec.start(buf)
         tag = dec.peek()
         assert tag == (asn1.Numbers.PrintableString, asn1.Types.Primitive, asn1.Classes.Universal)
+        assert str(tag) == "Tag(nr=<Numbers.PrintableString: 0x13>, typ=<Types.Primitive: 0x00>, cls=<Classes.Universal: 0x00>)"
         tag, val = dec.read()
         assert val == u'fooé'
 
@@ -507,6 +514,7 @@ class TestDecoder(object):
         dec.start(buf)
         tag = dec.peek()
         assert tag == (asn1.Numbers.Null, asn1.Types.Primitive, asn1.Classes.Universal)
+        assert str(tag) == "Tag(nr=<Numbers.Null: 0x05>, typ=<Types.Primitive: 0x00>, cls=<Classes.Universal: 0x00>)"
         tag, val = dec.read()
         assert val is None
 
@@ -552,6 +560,7 @@ class TestDecoder(object):
         dec.start(buf)
         tag = dec.peek()
         assert tag == (asn1.Numbers.Enumerated, asn1.Types.Primitive, asn1.Classes.Universal)
+        assert str(tag) == "Tag(nr=<Numbers.Enumerated: 0x0a>, typ=<Types.Primitive: 0x00>, cls=<Classes.Universal: 0x00>)"
         tag, val = dec.read()
         assert isinstance(val, int)
         assert val == 1
@@ -562,6 +571,7 @@ class TestDecoder(object):
         dec.start(buf)
         tag = dec.peek()
         assert tag == (asn1.Numbers.Sequence, asn1.Types.Constructed, asn1.Classes.Universal)
+        assert str(tag) == "Tag(nr=<Numbers.Sequence: 0x10>, typ=<Types.Constructed: 0x20>, cls=<Classes.Universal: 0x00>)"
         dec.enter()
         tag, val = dec.read()
         assert val == 1
@@ -574,6 +584,7 @@ class TestDecoder(object):
         dec.start(buf)
         tag = dec.peek()
         assert tag == (asn1.Numbers.Sequence, asn1.Types.Constructed, asn1.Classes.Universal)
+        assert str(tag) == "Tag(nr=<Numbers.Sequence: 0x10>, typ=<Types.Constructed: 0x20>, cls=<Classes.Universal: 0x00>)"
         dec.enter()
         tag, val = dec.read()
         assert val == 1
@@ -586,6 +597,7 @@ class TestDecoder(object):
         dec.start(buf)
         tag = dec.peek()
         assert tag == (asn1.Numbers.Set, asn1.Types.Constructed, asn1.Classes.Universal)
+        assert str(tag) == "Tag(nr=<Numbers.Set: 0x11>, typ=<Types.Constructed: 0x20>, cls=<Classes.Universal: 0x00>)"
         dec.enter()
         tag, val = dec.read()
         assert val == 1
@@ -598,6 +610,7 @@ class TestDecoder(object):
         dec.start(buf)
         tag = dec.peek()
         assert tag == (asn1.Numbers.Set, asn1.Types.Constructed, asn1.Classes.Universal)
+        assert str(tag) == "Tag(nr=<Numbers.Set: 0x11>, typ=<Types.Constructed: 0x20>, cls=<Classes.Universal: 0x00>)"
         dec.enter()
         tag, val = dec.read()
         assert val == 1
@@ -610,6 +623,7 @@ class TestDecoder(object):
         dec.start(buf)
         tag = dec.peek()
         assert tag == (1, asn1.Types.Constructed, asn1.Classes.Context)
+        assert str(tag) == "Tag(nr=1, typ=<Types.Constructed: 0x20>, cls=<Classes.Context: 0x80>)"
         dec.enter()
         tag, val = dec.read()
         assert val == 1
@@ -620,6 +634,7 @@ class TestDecoder(object):
         dec.start(buf)
         tag = dec.peek()
         assert tag == (1, asn1.Types.Constructed, asn1.Classes.Application)
+        assert str(tag) == "Tag(nr=1, typ=<Types.Constructed: 0x20>, cls=<Classes.Application: 0x40>)"
         dec.enter()
         tag, val = dec.read()
         assert val == 1
@@ -630,6 +645,7 @@ class TestDecoder(object):
         dec.start(buf)
         tag = dec.peek()
         assert tag == (1, asn1.Types.Constructed, asn1.Classes.Private)
+        assert str(tag) == "Tag(nr=1, typ=<Types.Constructed: 0x20>, cls=<Classes.Private: 0xc0>)"
         dec.enter()
         tag, val = dec.read()
         assert val == 1


### PR DESCRIPTION
Hello there! First time contributing. I've tried to follow the contributing steps but couldn't make tox detect my pyenv config. I manually tested 2.7 and 3.10.

I was playing around with an interactive python and some x509 certificate, but I had to refer to the documentation every time I peeked at the next tag because I never remember the enumeration values.

So this PR makes printing a Tag prints the value from the enums, instead of some obscure integer:

    Tag(nr=<Numbers.BitString: 0x03>, typ=<Types.Primitive: 0x00>, cls=<Classes.Universal: 0x00>)

Instead of

    Tag(nr=3, typ=0, cls=0)

Note that in case of a non-universal class, it keeps the `nr` as as integer. If I understood it correctly, non-universal class are for user-defined types, so `nr=1` isn't always a `Numbers.Boolean` right?

---

I've tried different approach before settling on the one proposed here. Another of my attemps was to try and change the `namedtuple` for a `collections.abc.Sequence` to get control on the `__init__` and `__repr__`. The code turned out too complicated due to the py2-compat.

---

By the way, running the tox tests on the master branch yields some errors.

flake8 complains about the unused `from numbers import Number` import. sphinx complains that the https://tox.wiki/en/latest/install.html url is not found (HTTP 404). sphinx autodoc complains that the docstrings of `asn1.Encoder.construct` is broken.